### PR TITLE
Fix byte-compile error

### DIFF
--- a/monroe.el
+++ b/monroe.el
@@ -39,6 +39,8 @@
 ;;; Code:
 
 (require 'comint)
+(eval-when-compile
+  (require 'cl))
 
 (defgroup monroe nil
   "Interaction with the nREPL Server."


### PR DESCRIPTION
I got following error at byte-compiling on Emacs 25.1 RC1

```
In monroe-dbind-response:
monroe.el:113:16:Warning: reference to free variable ‘for’
monroe.el:113:20:Warning: reference to free variable ‘key’
monroe.el:113:24:Warning: reference to free variable ‘in’
monroe.el:114:16:Warning: reference to free variable ‘collect’
monroe.el:232:1:Error: Symbol’s value as variable is void: for
```