### PR TITLE
This changes `monroe-eval-buffer' to preserve line numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,9 @@ code and where *monroe-interaction-mode* is activated.
 Keys                | Description
 --------------------|----------------------------
 <kbd>C-c C-c</kbd>  | Evaluate expression at point.
+<kbd>C-c C-l</kbd>  | Load a file.
 <kbd>C-c C-r</kbd>  | Evaluate region.
-<kbd>C-c C-k</kbd>  | Evaluate buffer.
+<kbd>C-c C-k</kbd>  | Evaluate current buffer.
 <kbd>C-c C-d</kbd>  | Describe symbol at point, showing documentation in REPL window.
 <kbd>C-c C-n</kbd>  | Evaluate namespace.
 <kbd>C-c C-b</kbd>  | Interrupt running job.

--- a/monroe.el
+++ b/monroe.el
@@ -462,17 +462,20 @@ inside a container.")
 
 (defun monroe-load-file (path)
   "Load file to running process, asking user for alternative path.
-This function, contrary to clojure-mode.el, will not use comint-mode for sending files
-as path can be remote location. For remote paths, use absolute path."
+This function, contrary to clojure-mode.el, will not use comint-mode for sending
+files as path can be remote location. For remote paths, use absolute path."
   (interactive
    (list
     (let ((n (buffer-file-name)))
       (read-file-name "Load file: " nil nil nil
                       (and n (file-name-nondirectory n))))))
+  (when (and (find-buffer-visiting path) (buffer-modified-p path))
+    (save-some-buffers nil (lambda () (equal buffer-file-name path))))
   (let ((full-path (convert-standard-filename (expand-file-name path))))
     (monroe-input-sender
      (get-buffer-process monroe-repl-buffer)
-     (format "(clojure.core/load-file \"%s\")" full-path))))
+     (format "(clojure.core/load-file \"%s\")"
+             (funcall monroe-translate-path-function full-path)))))
 
 (defun monroe-jump (var)
   "Jump to definition of var at point."


### PR DESCRIPTION
Note that this does change the semantics of C-c C-k because it will
load the file from disk, so unsaved changes will not be reflected. IMO
it's much more important to have line numbers; if you really need to
eval unsaved changes you can still use C-c C-r.

In order to avoid being surprised by this change, we now prompt to
save the current buffer if it's unsaved.