### PR TITLE
Display error messages with `message'.

### DIFF
--- a/monroe.el
+++ b/monroe.el
@@ -412,7 +412,9 @@ at the top of the file."
 
 (defun monroe-eval-doc (symbol)
   "Internal function to actually ask for symbol documentation via nrepl protocol."
-  (monroe-input-sender (get-buffer-process monroe-repl-buffer) (format "(clojure.repl/doc %s)" symbol)))
+  (monroe-input-sender
+   (get-buffer-process monroe-repl-buffer)
+   (format "(do (require 'clojure.repl) (clojure.repl/doc %s))" symbol)))
 
 (eval-when-compile '(require 'arc-mode))
 
@@ -458,7 +460,8 @@ inside a container.")
                  (if monroe-old-style-stacktraces
                      'clojure.stacktrace/print-stack-trace
                    'clojure.repl/pst))))
-    (monroe-send-eval-string (format "(%s *e)" pst)
+    (monroe-send-eval-string (format "(do (require (namespace '%s)) (%s *e))"
+                                     pst pst)
                              (monroe-make-response-handler))))
 
 (defun monroe-describe (symbol)


### PR DESCRIPTION
When `monroe-detail-stacktraces` is set and we are printing full stack
traces, also fetch the exception's message and display it using `message`.

This also includes a change which generalizes `monroe-old-style-stacktraces`;
instead of a boolean old/new it allows you to set an arbitrary stack trace
printing function, which allows you to use 3rd-party libs.

I am on the fence about whether this is the right place for this
functionality; maybe coupling it with `monroe-detail-stacktraces` is
not wise; what do you think?