### PR TITLE
Use .nrepl-port hint if available

### DIFF
--- a/monroe.el
+++ b/monroe.el
@@ -344,6 +344,14 @@ monroe-repl-buffer."
     str
     default))
 
+(defun monroe-locate-running-nrepl-host ()
+  "Return host of running nREPL server."
+  (let ((dir (locate-dominating-file default-directory ".nrepl-port")))
+    (when dir
+      (with-temp-buffer
+        (insert-file-contents (concat dir ".nrepl-port"))
+        (concat "localhost:" (buffer-string))))))
+
 (defun monroe-strip-protocol (host)
   "Check if protocol was given and strip it."
   (let ((host (replace-regexp-in-string "[ \t]" "" host)))
@@ -598,9 +606,10 @@ The following keys are available in `monroe-interaction-mode`:
   "Load monroe by setting up appropriate mode, asking user for
 connection endpoint."
   (interactive
-   (list
-    (read-string (format "Host (default '%s'): " monroe-default-host)
-                 nil nil monroe-default-host)))
+   (let ((host (or (monroe-locate-running-nrepl-host) monroe-default-host)))
+     (list
+      (read-string (format "Host (default '%s'): " host)
+                   nil nil host))))
   (unless (ignore-errors
             (with-current-buffer (get-buffer-create monroe-repl-buffer)
               (prog1


### PR DESCRIPTION
To avoid searching/entering the port manually (this is just a stripped down/simple version of the corresponding *cider* functionality)

Thanks for this nice package :+1: 