### PR TITLE
Use `pop-to-buffer` to re-use visible monroe window

### DIFF
--- a/monroe.el
+++ b/monroe.el
@@ -526,7 +526,7 @@ as path can be remote location. For remote paths, use absolute path."
 
 (defun monroe-switch-to-repl ()
   (interactive)
-  (switch-to-buffer monroe-repl-buffer))
+  (pop-to-buffer monroe-repl-buffer))
 
 (defun monroe-extract-keys (htable)
   "Get all keys from hashtable."


### PR DESCRIPTION
Currently when using `C-z C-z` I can nicely switch to `*monroe*` buffer, however, if it's visible already it would split current buffer and show it again.
This patch improves that workflow and instead will switch to visible Monroe buffer or replace current one if it's not visible.