### PR TITLE
Simple function to launch nrepl server via Leiningen

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,38 @@ Then, in Emacs:
 
 and follow the question about nREPL server location and port.
 
+### Starting the nREPL server
+
+You can start the nREPL server straight from Emacs by running:
+
+<kbd>M-x monroe-nrepl-server-start [RET]</kbd>
+
+and then connect as above.
+By default Monroe will start Leiningen REPL with command:
+
+`lein trampoline repl :headless`
+
+You can override this by setting the following variables:
+
+- `monroe-nrepl-server-cmd` - defaults to `lein`
+- `monroe-nrepl-server-cmd-args` - defaults to `trampoline repl :headless`
+- `monroe-nrepl-server-project-file` - defaults to `project.clj` - this is used
+   for finding your project's root and launching the REPL process in that location
+
+#### Boot configuration
+
+(*Note*: these are not verified!)
+
+For boot, set the following in your `init.el`:
+
+
+```elisp
+(setq monroe-nrepl-server-cmd "boot")
+(setq monroe-nrepl-server-cmd-args "repl -S")
+(setq monroe-nrepl-server-project-file "build.boot")
+```
+
+
 ## Keys and shortcuts
 
 ### Monroe shortcuts for code buffer

--- a/monroe.el
+++ b/monroe.el
@@ -528,6 +528,19 @@ as path can be remote location. For remote paths, use absolute path."
   (interactive)
   (pop-to-buffer monroe-repl-buffer))
 
+(defun monroe-start-lein-nrepl ()
+  "Starts NREPL via Leiningen's repl command"
+  (interactive)
+  (require 'term)
+  (let* ((cmd "lein")
+         (args "trampoline repl :headless")
+         (switches (split-string-and-unquote args))
+         (termbuf (apply 'make-term "lein repl" cmd nil switches)))
+    (set-buffer termbuf)
+    (term-mode)
+    (term-char-mode)
+    (switch-to-buffer termbuf)))
+
 (defun monroe-extract-keys (htable)
   "Get all keys from hashtable."
   (let (keys)

--- a/monroe.el
+++ b/monroe.el
@@ -112,6 +112,14 @@ e.g. 'clojure.stacktrace/print-stack-trace for old-style stack traces."
 is only advertised until first expression is evaluated, then is updated
 to the one used on nrepl side.")
 
+(defvar monroe-nrepl-server-cmd "lein"
+  "Command to start nrepl server. Defaults to Leiningen")
+
+(defvar monroe-nrepl-server-cmd-args "trampoline repl :headless"
+  "Arguments to pass to the nrepl command. Defaults to 'trampoline repl :headless'")
+
+(defvar monroe-nrepl-server-buffer-name "monroe nrepl server")
+
 (make-variable-buffer-local 'monroe-session)
 (make-variable-buffer-local 'monroe-requests)
 (make-variable-buffer-local 'monroe-requests-counter)
@@ -528,14 +536,14 @@ as path can be remote location. For remote paths, use absolute path."
   (interactive)
   (pop-to-buffer monroe-repl-buffer))
 
-(defun monroe-start-lein-nrepl ()
-  "Starts NREPL via Leiningen's repl command"
+(defun monroe-nrepl-server-start ()
+  "Starts nREPL server by invoking monroe-nrepl-server-cmd + monroe-nrepl-server-cmd-args"
   (interactive)
   (require 'term)
-  (let* ((cmd "lein")
-         (args "trampoline repl :headless")
-         (switches (split-string-and-unquote args))
-         (termbuf (apply 'make-term "lein repl" cmd nil switches)))
+  (let* ((cmd monroe-nrepl-server-cmd)
+         (switches (split-string-and-unquote monroe-nrepl-server-cmd-args))
+         (termbuf (apply 'make-term monroe-nrepl-server-buffer-name
+                         cmd nil switches)))
     (set-buffer termbuf)
     (term-mode)
     (term-char-mode)

--- a/monroe.el
+++ b/monroe.el
@@ -542,7 +542,7 @@ as path can be remote location. For remote paths, use absolute path."
   (pop-to-buffer monroe-repl-buffer))
 
 (defun monroe-nrepl-server-start ()
-  "Starts nrepl server. Uses monroe-nrepl-server-cmd + monroe-nrepl-server-cmd-args as the command."
+  "Starts nrepl server. Uses monroe-nrepl-server-cmd + monroe-nrepl-server-cmd-args as the command. Finds project root by locatin monroe-nrepl-server-project-file"
   (interactive)
   (let* ((cmd monroe-nrepl-server-cmd)
          (switches (split-string-and-unquote monroe-nrepl-server-cmd-args))

--- a/monroe.el
+++ b/monroe.el
@@ -348,9 +348,12 @@ monroe-repl-buffer."
     str
     default))
 
+(defun monroe-locate-port-file ()
+  (locate-dominating-file default-directory ".nrepl-port"))
+
 (defun monroe-locate-running-nrepl-host ()
   "Return host of running nREPL server."
-  (let ((dir (locate-dominating-file default-directory ".nrepl-port")))
+  (let ((dir (monroe-locate-port-file)))
     (when dir
       (with-temp-buffer
         (insert-file-contents (concat dir ".nrepl-port"))
@@ -544,7 +547,7 @@ as path can be remote location. For remote paths, use absolute path."
   (let* ((cmd monroe-nrepl-server-cmd)
          (switches (split-string-and-unquote monroe-nrepl-server-cmd-args))
          (nrepl-buf-name (concat "*" monroe-nrepl-server-buffer-name "*"))
-         (repl-started-dir (locate-dominating-file default-directory ".nrepl-port")))
+         (repl-started-dir (monroe-locate-port-file)))
     (if repl-started-dir
         (message (concat "Monroe: nREPL server already running in " repl-started-dir))
       (progn


### PR DESCRIPTION
I had this function in my Emacs config for a while now and I thought I'll share it.
It's quite naive in the implementation, it offers no help in finding the project's root path so my usual flow is:

- open `project.clj`
- start the repl via `M-x monroe-start-lein-nrepl`
- start Monroe repl via `M-x monroe`


Now, it's probably not a good idea for Monroe to become CIDER's equivalent, but even simpler Clojure integration modes like `inf-clojure` have *some* way of launching the REPL server in the background.

Let me know what you think!