### PR TITLE
Update the link to nREPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
      alt="Monroe" title="Monroe screenshot">
 </p>
 
-Monroe is [nREPL](https://github.com/clojure/tools.nrepl) client for
+Monroe is [nREPL](https://github.com/nrepl/nrepl) client for
 Emacs, focused on simplicity and easy distribution primarily targeting
 Clojure users.
 


### PR DESCRIPTION
nREPL these days has a new home (and a manual http://nrepl.readthedocs.io). 