### PR TITLE
Fix several completion bugs

### DIFF
--- a/monroe.el
+++ b/monroe.el
@@ -525,6 +525,7 @@ inside a container.")
          (sym (thing-at-point 'symbol))
          (response (monroe-send-sync-request (list "op" "completions"
                                                    "ns" ns
+                                                   "session" (monroe-current-session)
                                                    "prefix" sym))))
     (monroe-dbind-response response (completions)
       (when completions

--- a/monroe.el
+++ b/monroe.el
@@ -672,7 +672,7 @@ The following keys are available in `monroe-mode':
   (setq comint-input-sender 'monroe-input-sender)
   (setq mode-line-process '(":%s"))
   ;(set (make-local-variable 'font-lock-defaults) '(clojure-font-lock-keywords t))
-  (add-hook 'completion-at-point-functions #'monroe-completion-at-point 'local)
+  (add-hook 'completion-at-point-functions #'monroe-completion-at-point nil 'local)
   ;; a hack to keep comint happy
   (unless (comint-check-proc (current-buffer))
     (let ((fake-proc (start-process "monroe" (current-buffer) nil)))

--- a/monroe.el
+++ b/monroe.el
@@ -527,7 +527,7 @@ inside a container.")
          (ns (monroe-get-clojure-ns))
          (sym (thing-at-point 'symbol))
          (response (monroe-send-sync-request (list "op" "completions"
-                                                   "ns" ns
+                                                   "ns" (or ns "user")
                                                    "session" (monroe-current-session)
                                                    "prefix" sym))))
     (monroe-dbind-response response (completions)

--- a/monroe.el
+++ b/monroe.el
@@ -515,6 +515,9 @@ inside a container.")
              (goto-char (point-min))
              (forward-line (1- line)))))))))
 
+(defun monroe-completion-candidate (completions)
+  (monroe-dbind-response completions (candidate) candidate))
+
 (defun monroe-completion-at-point ()
   "Function to be used for the hook 'completion-at-point-functions'."
   (interactive)
@@ -529,7 +532,8 @@ inside a container.")
                                                    "prefix" sym))))
     (monroe-dbind-response response (completions)
       (when completions
-        (list start end (mapcar 'cdadr completions) nil)))))
+        (let ((candidates (mapcar 'monroe-completion-candidate completions)))
+          (list start end candidates nil))))))
 
 (defun monroe-get-stacktrace ()
   "When error happens, print the stack trace"


### PR DESCRIPTION
While debugging a new version of Jeejah, I encountered several bugs in Monroe's completion logic.

* The `completions` request was missing the `session` field, which all messages should have.
* The `monroe-completion-at-point` function was using `cdadr` to extract the "candidate" field instead of actually looking for the completion by name. This probably worked on whatever server it was originally tested with, but it would fail as soon as the response had a different number of fields from that.
* The `add-hook` call for `monroe-completion-at-point` was not correctly making the hook changes buffer-local.

However, even after fixing these bugs, I've been unable to get completion working. I've confirmed that responses come back over nrepl like such:

```
{:completions [{:candidate "tail!" :type "unknown"} {:candidate "table" :type "unknown"}]
 :id "1"
 :ns ">"
 :session "459523637"
 :status ["done"]}
```

but Monroe still does not correctly show or insert candidates returned by the server. Not sure what's going on there.